### PR TITLE
Throw error if ImageMagick binaries not found

### DIFF
--- a/lib/mongoose-gm.js
+++ b/lib/mongoose-gm.js
@@ -193,6 +193,12 @@
                                 resolve(doc);
                             },
                             function(err) {
+                                // ImageMagick binaries not found
+                                if(err.message.startsWith('Could not execute'))
+                                  release();
+                                  reject(err);
+                                  return
+
                                 //attachment could not be identified as an image
                                 //since the buffer is added as attachment anyway
                                 //we resolve it without thumbnails.


### PR DESCRIPTION
Currently mongoose-gm fails silently, assuming it's not an image.