### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/mongoose-gm.js
+++ b/lib/mongoose-gm.js
@@ -8,7 +8,7 @@
     var ReadWriteLock = require('rwlock');
     var gm = require('gm').subClass({imageMagick: true});
     var fs = require('fs');
-    var uuid = require('node-uuid');
+    var uuid = require('uuid');
     
     var _schema;    
     var _keys;

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "mongoose-gm",
-    "version": "0.1.23",
-    "description": "Mongoose plugin for manipulating images in your document schema",
-	"author":"Dennis Lemon <dennis.lemon@sudselekt.com>",
-	"scripts": {
-		"test": "NODE_ENV=test mocha -R spec test/"
-	},
-    "keywords": [
-        "mongoose",
-        "mongoose-plugin",
-        "mongodb",
-		"gridstore",
-		"attachements",
-        "mongoose-gridstore",
-        "imagemagick",
-        "gm",        
-        "thumbnail"
-    ],
-    "main": "index.js",
-    "dependencies": {
-        "mongoose":"latest",
-        "mongoose-gridstore":"latest",
-        "rwlock":"latest",
-        "modelo":"latest",
-        "gm":"latest",
-        "q":"latest",
-        "node-uuid":"latest"
-    },
-    "devDependencies": {
-        "mocha": "latest",
-        "chai": "latest"
-    },
-	"repository": {
-		"type": "git",
-		"url": "git@github.com:dlemon/mongoose-gm.git"
-	},
-    "license": "MIT",
-	"engines": {
-		"node": ">=0.10"
-	}
+  "name": "mongoose-gm",
+  "version": "0.1.23",
+  "description": "Mongoose plugin for manipulating images in your document schema",
+  "author": "Dennis Lemon <dennis.lemon@sudselekt.com>",
+  "scripts": {
+    "test": "NODE_ENV=test mocha -R spec test/"
+  },
+  "keywords": [
+    "mongoose",
+    "mongoose-plugin",
+    "mongodb",
+    "gridstore",
+    "attachements",
+    "mongoose-gridstore",
+    "imagemagick",
+    "gm",
+    "thumbnail"
+  ],
+  "main": "index.js",
+  "dependencies": {
+    "gm": "latest",
+    "modelo": "latest",
+    "mongoose": "latest",
+    "mongoose-gridstore": "latest",
+    "q": "latest",
+    "rwlock": "latest",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "mocha": "latest",
+    "chai": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:dlemon/mongoose-gm.git"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=0.10"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.